### PR TITLE
[FIX]Docker Compose DB 연결 레이스 컨디션 해결

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,12 @@ services:
       - ./db/csv:/app/db/csv
     env_file:
       - .env
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${DB_USER} -d ${DB_NAME} -h localhost -p 5432"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+      start_period: 5s
 
   bun:
     build:
@@ -24,7 +30,8 @@ services:
     ports:
       - "3000:3000"
     depends_on:
-      - db
+      db:
+        condition: service_healthy
     environment:
       DB_HOST: db
       DB_USER: ${DB_USER}
@@ -32,7 +39,7 @@ services:
       DB_NAME: ${DB_NAME}
       DB_PORT: ${DB_PORT}
     volumes:
-      - ./src:/app/src  # 소스 코드 볼륨 마운트
+      - ./src:/app/src # 소스 코드 볼륨 마운트
     env_file:
       - .env
 


### PR DESCRIPTION
## 문제
- `docker-compose down -v` 후 첫 실행 시 `bun-server`가 DB 연결 실패로 종료
- 두 번째 실행에서는 정상 작동하는 레이스 컨디션 발생

## 원인
- `depends_on`이 컨테이너 시작 순서만 보장하고, PostgreSQL 서비스 준비 완료는 보장하지 않음
- 첫 부팅 시 DB 초기화 중에 애플리케이션이 연결 시도하여 `ECONNREFUSED` 발생

## 해결책
- PostgreSQL에 `healthcheck` 추가
- `bun` 서비스의 `depends_on`을 `service_healthy` 조건으로 변경
- DB가 완전히 준비된 후에만 애플리케이션 시작

## 변경사항
- `docker-compose.yml`: DB healthcheck 및 의존성 조건 추가

## 테스트
- `docker-compose down -v && docker-compose up --build` 
- 첫 실행에서도 DB 연결 성공 확인